### PR TITLE
Release 1.2.1

### DIFF
--- a/com.adrienplazas.Metronome.json
+++ b/com.adrienplazas.Metronome.json
@@ -40,7 +40,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://gitlab.gnome.org/World/metronome/uploads/6434b82862b268d2c020a342ec051f88/metronome-1.2.0.tar.xz",
+                    "url": "https://gitlab.gnome.org/World/metronome/uploads/5efb0bac0bd09a15c5b027de4e4e4e32/metronome-1.2.1.tar.xz",
                     "sha256": "3896e6e0a97be7071a42fbf416db8a88d1e89cf662d0ccc7f007e09e13ac2f77"
                 }
             ]

--- a/com.adrienplazas.Metronome.json
+++ b/com.adrienplazas.Metronome.json
@@ -1,25 +1,26 @@
 {
-    "app-id": "com.adrienplazas.Metronome",
+    "id": "com.adrienplazas.Metronome",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "40",
+    "runtime-version": "44",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable"
     ],
     "command": "metronome",
-    "finish-args" : [
+    "finish-args": [
+        "--share=ipc",
         "--device=dri",
         "--socket=fallback-x11",
         "--socket=pulseaudio",
         "--socket=wayland"
     ],
-    "build-options" : {
-        "append-path" : "/usr/lib/sdk/rust-stable/bin",
-        "env" : {
-            "CARGO_HOME" : "/run/build/metronome/cargo"
+    "build-options": {
+        "append-path": "/usr/lib/sdk/rust-stable/bin",
+        "env": {
+            "CARGO_HOME": "/run/build/metronome/cargo"
         }
     },
-    "cleanup" : [
+    "cleanup": [
         "/include",
         "/lib/pkgconfig",
         "/man",
@@ -30,67 +31,17 @@
         "*.la",
         "*.a",
         "/lib/girepository-1.0",
-        "/share/gir-1.0",
-        "/bin/sassc"
+        "/share/gir-1.0"
     ],
     "modules": [
-        {
-            "name" : "libadwaita",
-            "buildsystem" : "meson",
-            "config-opts" : [
-                "-Dintrospection=disabled",
-                "-Dtests=false",
-                "-Dexamples=false"
-            ],
-            "sources" : [
-                {
-                    "type" : "git",
-                    "url" : "https://gitlab.gnome.org/GNOME/libadwaita.git",
-                    "tag" : "1.0.0-alpha.2",
-                    "commit" : "f5932ab4250c8e709958c6e75a1a4941a5f0f386"
-                }
-            ],
-            "modules": [
-                {
-                    "name" : "libsass",
-                    "buildsystem" : "meson",
-                    "cleanup" : [
-                        "*"
-                    ],
-                    "sources" : [
-                        {
-                            "type" : "git",
-                            "url" : "https://github.com/lazka/libsass.git",
-                            "branch" : "meson",
-                            "commit" : "302397c0c8ae2d7ab02f45ea461c2c3d768f248e"
-                        }
-                    ]
-                },
-                {
-                    "name" : "sassc",
-                    "buildsystem" : "meson",
-                    "cleanup" : [
-                        "*"
-                    ],
-                    "sources" : [
-                        {
-                            "type" : "git",
-                            "url" : "https://github.com/lazka/sassc.git",
-                            "branch" : "meson",
-                            "commit" : "82803377c33247265d779af034eceb5949e78354"
-                        }
-                    ]
-                }
-            ]
-        },
         {
             "name": "metronome",
             "buildsystem": "meson",
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://gitlab.gnome.org/aplazas/metronome/uploads/8c0b6d8f7f15fd9f5db408bacecad76f/metronome-1.1.0.tar.xz",
-                    "sha256": "19fd7f14cc03b4500b40045ae6f21d33edfe776a00c929b13abb211a8f0a8807"
+                    "url": "https://gitlab.gnome.org/World/metronome/uploads/6434b82862b268d2c020a342ec051f88/metronome-1.2.0.tar.xz",
+                    "sha256": "3896e6e0a97be7071a42fbf416db8a88d1e89cf662d0ccc7f007e09e13ac2f77"
                 }
             ]
         }


### PR DESCRIPTION
Updates to the new [1.2.1 release](https://gitlab.gnome.org/World/metronome/-/releases/1.2.1), finally updating the runtime to 44.

As a sidenote, neither I nor @Ratfink, the new maintainers for this project, are currently members of this GitHub project, so we cannot merge this ourselves.