### PR TITLE
Remove CARGO_HOME from manifest

### DIFF
--- a/com.adrienplazas.Metronome.json
+++ b/com.adrienplazas.Metronome.json
@@ -15,10 +15,7 @@
         "--socket=wayland"
     ],
     "build-options": {
-        "append-path": "/usr/lib/sdk/rust-stable/bin",
-        "env": {
-            "CARGO_HOME": "/run/build/metronome/cargo"
-        }
+        "append-path": "/usr/lib/sdk/rust-stable/bin"
     },
     "cleanup": [
         "/include",


### PR DESCRIPTION
Other rust projects do not need this, this should work. Ill update once I confirm it works.