### PR TITLE
Release 1.3.0

### DIFF
--- a/com.adrienplazas.Metronome.json
+++ b/com.adrienplazas.Metronome.json
@@ -15,7 +15,10 @@
         "--socket=wayland"
     ],
     "build-options": {
-        "append-path": "/usr/lib/sdk/rust-stable/bin"
+        "append-path": "/usr/lib/sdk/rust-stable/bin",
+        "env": {
+            "CARGO_HOME": "/run/build/metronome/cargo"
+        }
     },
     "cleanup": [
         "/include",
@@ -37,8 +40,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://gitlab.gnome.org/World/metronome/uploads/5efb0bac0bd09a15c5b027de4e4e4e32/metronome-1.2.1.tar.xz",
-                    "sha256": "3896e6e0a97be7071a42fbf416db8a88d1e89cf662d0ccc7f007e09e13ac2f77"
+                    "url": "https://gitlab.gnome.org/World/metronome/uploads/0fff68c135a2e6d6bf94d17d857f83d5/metronome-1.3.0.tar.xz",
+                    "sha256": "eb7a25e64084762f58573c33d09e0bf7167b322056f307dfee4d1438580f18cc"
                 }
             ]
         }


### PR DESCRIPTION
Updates to the [v1.3.0 release](https://gitlab.gnome.org/World/metronome/-/releases/1.3.0).