### PR TITLE
Upgrade to GNOME Platform 46

### DIFF
--- a/com.adrienplazas.Metronome.json
+++ b/com.adrienplazas.Metronome.json
@@ -1,7 +1,7 @@
 {
     "id": "com.adrienplazas.Metronome",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
Upgrades the runtime's dependency on `org.gnome.Platform` to verison 46 so at least it isn't using an end-of-life runtime anymore.